### PR TITLE
Sample weighted distribution

### DIFF
--- a/torchkde/modules.py
+++ b/torchkde/modules.py
@@ -201,7 +201,8 @@ class KernelDensity(nn.Module):
             raise NotImplementedError()
 
         data = torch.tensor(self.tree_.data)
-        idxs = torch.randint(data.shape[0], (n_samples,))
+        # idxs = torch.randint(data.shape[0], (n_samples,))
+        idxs = torch.distributions.Categorical(probs=self.sample_weight).sample((n_samples,))
 
         X = self.bandwidth * torch.randn(n_samples, data.shape[1]) + data[idxs]
 

--- a/torchkde/modules.py
+++ b/torchkde/modules.py
@@ -201,7 +201,6 @@ class KernelDensity(nn.Module):
             raise NotImplementedError()
 
         data = torch.tensor(self.tree_.data)
-        # idxs = torch.randint(data.shape[0], (n_samples,))
         idxs = torch.distributions.Categorical(probs=self.sample_weight).sample((n_samples,))
 
         X = self.bandwidth * torch.randn(n_samples, data.shape[1]) + data[idxs]

--- a/torchkde/modules.py
+++ b/torchkde/modules.py
@@ -200,7 +200,7 @@ class KernelDensity(nn.Module):
         if self.kernel not in ["gaussian"]:
             raise NotImplementedError()
 
-        data = torch.tensor(self.tree_.data)
+        data = self.tree_.data.detach().clone()
         idxs = torch.distributions.Categorical(probs=self.sample_weight).sample((n_samples,))
 
         X = self.bandwidth * torch.randn(n_samples, data.shape[1]) + data[idxs]


### PR DESCRIPTION
[Modules] sample the Gaussian kernel with respect to sample_weight

modules.sample() drew sample indices from a uniform distribution. This does not respect the weights of the samples, which can be passed in fit(X, sample_weights=...). Fix this issue by changing sampling from a uniform distribution to a Categorical distribution.

Add a test to confirm the functionality.